### PR TITLE
Misc updates to the template

### DIFF
--- a/SwiftAppTemplate/.gitignore
+++ b/SwiftAppTemplate/.gitignore
@@ -1,0 +1,1 @@
+xcuserdata

--- a/SwiftAppTemplate/SwiftAppTemplate.xcodeproj/project.pbxproj
+++ b/SwiftAppTemplate/SwiftAppTemplate.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 51;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,7 +11,7 @@
 		196235BE2272584D00B06E3C /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196235BD2272584D00B06E3C /* RootViewController.swift */; };
 		196235C32272584E00B06E3C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 196235C22272584E00B06E3C /* Assets.xcassets */; };
 		196235C62272584E00B06E3C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 196235C42272584E00B06E3C /* LaunchScreen.storyboard */; };
-		196235DC2278E73700B06E3C /* ListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196235DB2278E73700B06E3C /* ListViewController.swift */; };
+		196235DC2278E73700B06E3C /* DiscoveryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196235DB2278E73700B06E3C /* DiscoveryViewController.swift */; };
 		196235DE227A1E0400B06E3C /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196235DD227A1E0400B06E3C /* MainViewController.swift */; };
 		196235E0227A237C00B06E3C /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 196235DF227A237C00B06E3C /* APIClient.swift */; };
 		197F4066227A561200C7A2EA /* UIViewController+Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 197F4065227A561200C7A2EA /* UIViewController+Error.swift */; };
@@ -25,7 +25,7 @@
 		196235C22272584E00B06E3C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		196235C52272584E00B06E3C /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		196235C72272584E00B06E3C /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		196235DB2278E73700B06E3C /* ListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListViewController.swift; sourceTree = "<group>"; };
+		196235DB2278E73700B06E3C /* DiscoveryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscoveryViewController.swift; sourceTree = "<group>"; };
 		196235DD227A1E0400B06E3C /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		196235DF227A237C00B06E3C /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		197F4065227A561200C7A2EA /* UIViewController+Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Error.swift"; sourceTree = "<group>"; };
@@ -74,7 +74,7 @@
 				196235C72272584E00B06E3C /* Info.plist */,
 				196235DF227A237C00B06E3C /* APIClient.swift */,
 				197F4065227A561200C7A2EA /* UIViewController+Error.swift */,
-				196235DB2278E73700B06E3C /* ListViewController.swift */,
+				196235DB2278E73700B06E3C /* DiscoveryViewController.swift */,
 				196235DD227A1E0400B06E3C /* MainViewController.swift */,
 			);
 			path = SwiftAppTemplate;
@@ -214,7 +214,7 @@
 			files = (
 				196235BE2272584D00B06E3C /* RootViewController.swift in Sources */,
 				196235BC2272584D00B06E3C /* AppDelegate.swift in Sources */,
-				196235DC2278E73700B06E3C /* ListViewController.swift in Sources */,
+				196235DC2278E73700B06E3C /* DiscoveryViewController.swift in Sources */,
 				197F4066227A561200C7A2EA /* UIViewController+Error.swift in Sources */,
 				196235E0227A237C00B06E3C /* APIClient.swift in Sources */,
 				196235DE227A1E0400B06E3C /* MainViewController.swift in Sources */,

--- a/SwiftAppTemplate/SwiftAppTemplate.xcodeproj/project.pbxproj
+++ b/SwiftAppTemplate/SwiftAppTemplate.xcodeproj/project.pbxproj
@@ -359,6 +359,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = SwiftAppTemplate/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -378,6 +379,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = Y28TH9SHX7;
 				INFOPLIST_FILE = SwiftAppTemplate/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/SwiftAppTemplate/SwiftAppTemplate/APIClient.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/APIClient.swift
@@ -38,7 +38,7 @@ class APIClient {
 //        }
 //        var responseURL = backendURL
 //        for component in pathComponents {
-//            responseURL = backendURL.appendingPathComponent(component)
+//            responseURL = responseURL.appendingPathComponent(component)
 //        }
 //        return responseURL
 //    }
@@ -61,14 +61,12 @@ class APIClient {
 //        }
 //    }
 //
-//    func capturePaymentIntent(_ paymentIntentId: String, stripeAccount: String?, additionalParams: [String: Any]? = nil, completion: @escaping (Error?) -> Void) {
+//    func capturePaymentIntent(_ paymentIntentId: String, additionalParams: [String: Any]? = nil, completion: @escaping (Error?) -> Void) {
 //        let url = self.urlWithPathComponents(["payment_intents", paymentIntentId, "capture"])
-//        let headers = HTTPHeaders(["Stripe-Account": stripeAccount ?? ""])
 //        AF.request(url,
 //                   method: .post,
-//                   parameters: additionalParams,
-//                   headers: headers)
-//            .responseJSON(completionHandler: { response in
+//                   parameters: additionalParams)
+//            .responseString(completionHandler: { response in
 //                completion(response.error)
 //            })
 //    }

--- a/SwiftAppTemplate/SwiftAppTemplate/APIClient.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/APIClient.swift
@@ -7,6 +7,7 @@
 //
 
 import Alamofire
+//import StripeTerminal
 
 class APIClient {
 
@@ -23,27 +24,82 @@ class APIClient {
      fetchConnectionToken once you have StripeTerminal installed in the app.
      */
 
-    static var backendUrl: String = ""
+    static let backendUrl: String = ""
 
+    static let defaultError = NSError(domain: "APIClient Error",
+                                      code: 1,
+                                      userInfo: [
+                                        NSLocalizedDescriptionKey: "APIClient request failed.",
+    ])
+
+//    func urlWithPathComponents(_ pathComponents: [String]) -> URL {
+//        guard let backendURL = URL(string: APIClient.backendUrl) else {
+//            fatalError()
+//        }
+//        var responseURL = backendURL
+//        for component in pathComponents {
+//            responseURL = backendURL.appendingPathComponent(component)
+//        }
+//        return responseURL
+//    }
+//
 //    func fetchConnectionToken(_ completion: @escaping ConnectionTokenCompletionBlock) {
-//        if let backendUrl = URL(string: APIClient.backendUrl) {
-//            let url = backendUrl.appendingPathComponent("connection_token")
-//            let params: [String: Any] = [:] // whatever parameters necessary for your backend to authenticate the client
+//        let url = self.urlWithPathComponents(["connection_token"])
+//        let params: [String: Any] = [:] // whatever parameters necessary for your backend to authenticate the client
 //
-//
-//            AF.request(url, method: .post, parameters: params)
-//                .responseJSON { responseJSON in
-//                    switch responseJSON.result {
-//                    case .success(let json):
-//                        if let json = json as? [String: AnyObject],
-//                            let secret = json["secret"] as? String {
-//                            completion(secret, nil)
-//                        }
-//                    case .failure(let error):
-//                        completion(nil, error)
+//        AF.request(url, method: .post, parameters: params)
+//            .responseJSON { responseJSON in
+//                switch responseJSON.result {
+//                case .success(let json):
+//                    if let json = json as? [String: AnyObject],
+//                        let secret = json["secret"] as? String {
+//                        completion(secret, nil)
 //                    }
-//            }
+//                case .failure(let error):
+//                    completion(nil, error)
+//                }
 //        }
 //    }
-
+//
+//
+//    func createPaymentIntent(_ paymentIntentParams: PaymentIntentParameters,
+//                             stripeAccount: String? = nil,
+//                             completion: @escaping (PaymentIntent?, Error?) -> Void) {
+//        let url = self.urlWithPathComponents(["create_payment_intent"])
+//        let headers = HTTPHeaders(["Stripe-Account": stripeAccount ?? ""])
+//
+//        let params: Parameters = [
+//            "amount": paymentIntentParams.amount,
+//            "currency": paymentIntentParams.currency,
+//            // Add other PaymentIntentParameters as needed
+//            "payment_method_types": ["card_present"],
+//            "capture_method": "manual",
+//        ]
+//
+//        AF.request(url,
+//                   method: .post,
+//                   parameters: params,
+//                   headers: headers)
+//            .responseJSON(completionHandler: { response in
+//                if let json = response.value as? [AnyHashable : Any],
+//                    let paymentIntent = PaymentIntent.decodedObject(fromJSON: json) {
+//                    completion(paymentIntent, nil)
+//                } else {
+//                    // defaultError covers missing/invalid payment intent
+//                    completion(nil, response.error ?? APIClient.defaultError)
+//                }
+//            })
+//    }
+//
+//    func capturePaymentIntent(_ paymentIntentId: String, stripeAccount: String?, additionalParams: [String: Any]? = nil, completion: @escaping (Error?) -> Void) {
+//        let url = self.urlWithPathComponents(["payment_intents", paymentIntentId, "capture"])
+//        let headers = HTTPHeaders(["Stripe-Account": stripeAccount ?? ""])
+//        AF.request(url,
+//                   method: .post,
+//                   parameters: additionalParams,
+//                   headers: headers)
+//            .responseJSON(completionHandler: { response in
+//                completion(response.error)
+//            })
+//    }
 }

--- a/SwiftAppTemplate/SwiftAppTemplate/APIClient.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/APIClient.swift
@@ -61,36 +61,6 @@ class APIClient {
 //        }
 //    }
 //
-//
-//    func createPaymentIntent(_ paymentIntentParams: PaymentIntentParameters,
-//                             stripeAccount: String? = nil,
-//                             completion: @escaping (PaymentIntent?, Error?) -> Void) {
-//        let url = self.urlWithPathComponents(["create_payment_intent"])
-//        let headers = HTTPHeaders(["Stripe-Account": stripeAccount ?? ""])
-//
-//        let params: Parameters = [
-//            "amount": paymentIntentParams.amount,
-//            "currency": paymentIntentParams.currency,
-//            // Add other PaymentIntentParameters as needed
-//            "payment_method_types": ["card_present"],
-//            "capture_method": "manual",
-//        ]
-//
-//        AF.request(url,
-//                   method: .post,
-//                   parameters: params,
-//                   headers: headers)
-//            .responseJSON(completionHandler: { response in
-//                if let json = response.value as? [AnyHashable : Any],
-//                    let paymentIntent = PaymentIntent.decodedObject(fromJSON: json) {
-//                    completion(paymentIntent, nil)
-//                } else {
-//                    // defaultError covers missing/invalid payment intent
-//                    completion(nil, response.error ?? APIClient.defaultError)
-//                }
-//            })
-//    }
-//
 //    func capturePaymentIntent(_ paymentIntentId: String, stripeAccount: String?, additionalParams: [String: Any]? = nil, completion: @escaping (Error?) -> Void) {
 //        let url = self.urlWithPathComponents(["payment_intents", paymentIntentId, "capture"])
 //        let headers = HTTPHeaders(["Stripe-Account": stripeAccount ?? ""])

--- a/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
@@ -31,7 +31,7 @@ class DiscoveryViewController: UITableViewController {
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissAction))
 
-        let activityIndicator = UIActivityIndicatorView.init(style: .gray)
+        let activityIndicator = UIActivityIndicatorView.init(style: .medium)
         let barButton = UIBarButtonItem(customView: activityIndicator)
         activityIndicator.startAnimating()
         navigationItem.rightBarButtonItem = barButton

--- a/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
@@ -30,6 +30,11 @@ class DiscoveryViewController: UITableViewController {
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: DiscoveryViewController.cellReuseIdentifier)
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissAction))
+
+        let activityIndicator = UIActivityIndicatorView.init(style: .gray)
+        let barButton = UIBarButtonItem(customView: activityIndicator)
+        activityIndicator.startAnimating()
+        navigationItem.rightBarButtonItem = barButton
     }
 
     @objc func dismissAction() {

--- a/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
@@ -7,22 +7,16 @@
 //
 
 import UIKit
+//import StripeTerminal // Uncomment after setting up the framework
 
-class DiscoveryViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
-
-    private let tableView = UITableView(frame: CGRect.zero)
-    private weak var cancelButton: UIBarButtonItem?
-
+class DiscoveryViewController: UITableViewController/*, DiscoveryDelegate */ {
     private static var cellReuseIdentifier = "readerCell"
 
-    // This could be changed to an actual type.
-    private var items: [Any] = []
+    // This could be changed to the Reader type.
+    private var items: [String] = []
 
-    init(_ items: [Any]) {
+    init() {
         super.init(nibName: nil, bundle: nil)
-        tableView.delegate = self
-        tableView.dataSource = self
-        self.items = items
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -34,64 +28,50 @@ class DiscoveryViewController: UIViewController, UITableViewDelegate, UITableVie
 
         title = "Connect Reader"
 
-        view.backgroundColor = UIColor.white
-
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: DiscoveryViewController.cellReuseIdentifier)
-        tableView.separatorStyle = .none
-        view.addSubview(tableView)
 
-        tableView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            tableView.topAnchor.constraint(equalTo: view.topAnchor),
-            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor)
-        ])
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissAction))
 
-        let cancelButton = UIBarButtonItem(title: "Cancel", style: .plain, target: self, action: #selector(dismissAction))
-        self.cancelButton = cancelButton
-        navigationItem.leftBarButtonItem = cancelButton
-
-        tableView.reloadData()
+// Make sure to uncomment the DiscoveryDelegate protocol part above too
+//        Terminal.shared.discoverReaders(DiscoveryConfiguration(deviceType: {you pick}, discoveryMethod: {you pick}, simulated: false), delegate: self) { [unowned self] error in
+//            if let error = error {
+//                self.presentErrorAlert(error.localizedDescription)
+//            }
+//        }
     }
 
     @objc func dismissAction() {
         navigationController?.popViewController(animated: true)
     }
 
-    // Mark - UITableViewDelegate
+    // MARK: - DiscoveryDelegate
 
-    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+//    func terminal(_ terminal: Terminal, didUpdateDiscoveredReaders readers: [Reader]) {
+//        for reader in readers {
+//            items.removeAll { $0 == reader.serialNumber } // make sure we don't have duplicates
+//            items.append(reader.serialNumber)
+//        }
+//        self.tableView.reloadData()
+//    }
+
+    // MARK: - UITableViewDelegate
+
+    override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // TODO: This is method is called once any of the items on a list have
-        // been selected.
+        // been selected. If you update the `items` to store `Reader`s you probably
+        // want to connect to that reader now.
     }
 
-    // Mark - UITableViewDataSource
+    // MARK: - UITableViewDataSource
 
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return items.count
     }
 
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: DiscoveryViewController.cellReuseIdentifier) ??  UITableViewCell(style: .default, reuseIdentifier: DiscoveryViewController.cellReuseIdentifier)
 
-        // You can attempt to cast to a given object with as? and then safely
-        // access an object specific properity in order to set the textLabel
-        // of the cell to something meaningful.
-        if let text = items[indexPath.row] as? String {
-            cell.textLabel?.text = text
-        }
-
-        let bottomBorder = UIView()
-        bottomBorder.backgroundColor = UIColor.lightGray
-        cell.contentView.addSubview(bottomBorder)
-        bottomBorder.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            bottomBorder.heightAnchor.constraint(equalToConstant: 1.0),
-            bottomBorder.leadingAnchor.constraint(equalTo: cell.leadingAnchor),
-            bottomBorder.trailingAnchor.constraint(equalTo: cell.trailingAnchor),
-            bottomBorder.bottomAnchor.constraint(equalTo: cell.bottomAnchor),
-        ])
+        cell.textLabel?.text = items[indexPath.row]
 
         return cell
     }

--- a/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
@@ -7,9 +7,8 @@
 //
 
 import UIKit
-//import StripeTerminal // Uncomment after setting up the framework
 
-class DiscoveryViewController: UITableViewController/*, DiscoveryDelegate */ {
+class DiscoveryViewController: UITableViewController {
     private static var cellReuseIdentifier = "readerCell"
 
     // This could be changed to the Reader type.
@@ -31,28 +30,11 @@ class DiscoveryViewController: UITableViewController/*, DiscoveryDelegate */ {
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: DiscoveryViewController.cellReuseIdentifier)
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissAction))
-
-// Make sure to uncomment the DiscoveryDelegate protocol part above too
-//        Terminal.shared.discoverReaders(DiscoveryConfiguration(deviceType: {you pick}, discoveryMethod: {you pick}, simulated: false), delegate: self) { [unowned self] error in
-//            if let error = error {
-//                self.presentErrorAlert(error.localizedDescription)
-//            }
-//        }
     }
 
     @objc func dismissAction() {
         navigationController?.popViewController(animated: true)
     }
-
-    // MARK: - DiscoveryDelegate
-
-//    func terminal(_ terminal: Terminal, didUpdateDiscoveredReaders readers: [Reader]) {
-//        for reader in readers {
-//            items.removeAll { $0 == reader.serialNumber } // make sure we don't have duplicates
-//            items.append(reader.serialNumber)
-//        }
-//        self.tableView.reloadData()
-//    }
 
     // MARK: - UITableViewDelegate
 

--- a/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/DiscoveryViewController.swift
@@ -1,5 +1,5 @@
 //
-//  ListViewController.swift
+//  DiscoveryViewController.swift
 //  SwiftAppTemplate
 //
 //  Created by Catriona Scott on 4/30/19.
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class ListViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
+class DiscoveryViewController: UIViewController, UITableViewDelegate, UITableViewDataSource {
 
     private let tableView = UITableView(frame: CGRect.zero)
     private weak var cancelButton: UIBarButtonItem?
@@ -36,7 +36,7 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
 
         view.backgroundColor = UIColor.white
 
-        tableView.register(UITableViewCell.self, forCellReuseIdentifier: ListViewController.cellReuseIdentifier)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: DiscoveryViewController.cellReuseIdentifier)
         tableView.separatorStyle = .none
         view.addSubview(tableView)
 
@@ -73,7 +73,7 @@ class ListViewController: UIViewController, UITableViewDelegate, UITableViewData
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: ListViewController.cellReuseIdentifier) ??  UITableViewCell(style: .default, reuseIdentifier: ListViewController.cellReuseIdentifier)
+        let cell = tableView.dequeueReusableCell(withIdentifier: DiscoveryViewController.cellReuseIdentifier) ??  UITableViewCell(style: .default, reuseIdentifier: DiscoveryViewController.cellReuseIdentifier)
 
         // You can attempt to cast to a given object with as? and then safely
         // access an object specific properity in order to set the textLabel

--- a/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
@@ -136,8 +136,8 @@ class MainViewController: UIViewController, UITextFieldDelegate {
         // loadingContainerView.isHidden = false
         // loadingIndicator.startAnimating()
 
-        let listViewController = ListViewController(["test", "test", "test", "test"])
-        navigationController?.pushViewController(listViewController, animated: true)
+        let discoveryViewController = DiscoveryViewController(["test", "test", "test", "test"])
+        navigationController?.pushViewController(discoveryViewController, animated: true)
     }
 
     @objc func collectPayment(sender: UIButton) {

--- a/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
@@ -9,20 +9,12 @@
 import UIKit
 
 class MainViewController: UIViewController, UITextFieldDelegate {
-    private let discoverReadersButton = UIButton()
-    private let collectPaymentButton = UIButton()
     private let paymentTextField = UITextField()
-    private let containerView = UIView()
-    private let loadingIndicator = UIActivityIndicatorView()
-    private let loadingContainerView = UIView()
-    private let loadingLabel = UILabel()
-
     private static let spacing: CGFloat = 50.0
     private static let stripeBlue = UIColor(red: 103.0/255.0, green:  114.0/255.0, blue: 229.0/255.0, alpha: 1.0)
 
     init() {
         super.init(nibName: nil, bundle: nil)
-        paymentTextField.delegate = self
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -35,107 +27,43 @@ class MainViewController: UIViewController, UITextFieldDelegate {
         title = "Example App"
         view.backgroundColor = UIColor.white
 
+        paymentTextField.delegate = self
+
+        let discoverReadersButton = MainViewController.stripeyButton()
         discoverReadersButton.setTitle("Discover Readers", for: .normal)
-        discoverReadersButton.setTitleColor(UIColor.white, for: .normal)
-        discoverReadersButton.layer.borderWidth = 1.0
-        discoverReadersButton.layer.borderColor = MainViewController.stripeBlue.cgColor
-        discoverReadersButton.layer.cornerRadius = 4.0
-        discoverReadersButton.titleEdgeInsets = UIEdgeInsets(top: 20.0, left: 10.0, bottom: 20.0, right: 10.0)
-        discoverReadersButton.backgroundColor = MainViewController.stripeBlue
         discoverReadersButton.addTarget(self, action: #selector(discoverReader), for: .touchUpInside)
 
-
+        let collectPaymentButton = MainViewController.stripeyButton()
         collectPaymentButton.setTitle("Collect Payment", for: .normal)
-        collectPaymentButton.setTitleColor(UIColor.white, for: .normal)
-        collectPaymentButton.layer.borderWidth = 1.0
-        collectPaymentButton.layer.borderColor = MainViewController.stripeBlue.cgColor
-        collectPaymentButton.layer.cornerRadius = 4.0
-        collectPaymentButton.titleEdgeInsets = UIEdgeInsets(top: 20.0, left: 10.0, bottom: 20.0, right: 10.0)
-        collectPaymentButton.backgroundColor = MainViewController.stripeBlue
         collectPaymentButton.addTarget(self, action: #selector(collectPayment), for: .touchUpInside)
 
         paymentTextField.placeholder = "0"
-        paymentTextField.keyboardType = .numbersAndPunctuation
+        paymentTextField.keyboardType = .numberPad
         paymentTextField.borderStyle = .roundedRect
 
-        paymentTextField.leftView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 10.0, height: 0.0))
-        paymentTextField.leftViewMode = .always
-
-        loadingContainerView.isHidden = true
-        loadingContainerView.backgroundColor = UIColor(white: 0.0, alpha: 0.75)
-
-        loadingLabel.textColor = UIColor.white
-
-        view.addSubview(containerView)
-        containerView.addSubview(discoverReadersButton)
-        containerView.addSubview(collectPaymentButton)
-        containerView.addSubview(paymentTextField)
-        view.addSubview(loadingContainerView)
-        loadingContainerView.addSubview(loadingIndicator)
-        loadingContainerView.addSubview(loadingLabel)
-
-        containerView.translatesAutoresizingMaskIntoConstraints = false;
-        NSLayoutConstraint.activate([
-            containerView.centerYAnchor.constraint(equalTo: view.centerYAnchor, constant: -MainViewController.spacing),
-            containerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-            containerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+        let stackView = UIStackView(arrangedSubviews: [
+            UIView(), // Spacer()
+            discoverReadersButton,
+            paymentTextField,
+            collectPaymentButton,
+            UIView(), // Spacer()
         ])
+        stackView.axis = .vertical
+        stackView.spacing = MainViewController.spacing
+        stackView.isLayoutMarginsRelativeArrangement = true
+        view.addSubview(stackView)
 
-        discoverReadersButton.translatesAutoresizingMaskIntoConstraints = false;
+        stackView.translatesAutoresizingMaskIntoConstraints = false;
         NSLayoutConstraint.activate([
-            discoverReadersButton.topAnchor.constraint(equalTo: containerView.topAnchor),
-            discoverReadersButton.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            discoverReadersButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: MainViewController.spacing),
-            discoverReadersButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -MainViewController.spacing),
-        ])
-
-        paymentTextField.translatesAutoresizingMaskIntoConstraints = false;
-        NSLayoutConstraint.activate([
-            paymentTextField.topAnchor.constraint(equalTo: discoverReadersButton.bottomAnchor, constant: MainViewController.spacing),
-            paymentTextField.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            paymentTextField.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: MainViewController.spacing),
-            paymentTextField.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -MainViewController.spacing),
-            paymentTextField.heightAnchor.constraint(equalTo: discoverReadersButton.heightAnchor),
-        ])
-
-
-        collectPaymentButton.translatesAutoresizingMaskIntoConstraints = false;
-        NSLayoutConstraint.activate([
-            collectPaymentButton.topAnchor.constraint(equalTo: paymentTextField.bottomAnchor, constant: MainViewController.spacing),
-            collectPaymentButton.centerXAnchor.constraint(equalTo: containerView.centerXAnchor),
-            collectPaymentButton.bottomAnchor.constraint(equalTo: containerView.bottomAnchor),
-            collectPaymentButton.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: MainViewController.spacing),
-            collectPaymentButton.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -MainViewController.spacing),
-        ])
-
-        loadingContainerView.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            loadingContainerView.topAnchor.constraint(equalTo: view.topAnchor),
-            loadingContainerView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
-            loadingContainerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            loadingContainerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-        ])
-
-        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            loadingIndicator.centerXAnchor.constraint(equalTo: loadingContainerView.centerXAnchor),
-            loadingIndicator.centerYAnchor.constraint(equalTo: loadingContainerView.centerYAnchor),
-        ])
-
-        loadingLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            loadingLabel.topAnchor.constraint(equalTo: loadingIndicator.bottomAnchor, constant: MainViewController.spacing),
-            loadingLabel.centerXAnchor.constraint(equalTo: loadingContainerView.centerXAnchor)
+            stackView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            stackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -MainViewController.spacing),
+            stackView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            stackView.leftAnchor.constraint(equalTo: self.view.leftAnchor, constant: MainViewController.spacing),
         ])
     }
 
-
     @objc func discoverReader(sender: UIButton) {
-        // The following can be using to show a loading screen and message.
-        // loadingLabel.text = ""
-        // loadingContainerView.isHidden = false
-        // loadingIndicator.startAnimating()
-
+        // Use the DiscoveryVC to start discovery and connect to a reader (or return a reader to connect to)
         let discoveryViewController = DiscoveryViewController()
         navigationController?.pushViewController(discoveryViewController, animated: true)
     }
@@ -163,6 +91,16 @@ class MainViewController: UIViewController, UITextFieldDelegate {
             presentErrorAlert("Please enter valid integer.")
             return
         }
+    }
 
+    private static func stripeyButton() -> UIButton {
+        let button = UIButton()
+        button.setTitleColor(UIColor.white, for: .normal)
+        button.layer.borderWidth = 1.0
+        button.layer.borderColor = MainViewController.stripeBlue.cgColor
+        button.layer.cornerRadius = 4.0
+        button.titleEdgeInsets = UIEdgeInsets(top: 20.0, left: 10.0, bottom: 20.0, right: 10.0)
+        button.backgroundColor = MainViewController.stripeBlue
+        return button
     }
 }

--- a/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
@@ -87,7 +87,7 @@ class MainViewController: UIViewController, UITextFieldDelegate {
             return
         }
 
-        guard let _ = Int(amountString) else {
+        guard let _ = UInt(amountString) else {
             presentErrorAlert("Please enter valid integer.")
             return
         }

--- a/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
@@ -136,7 +136,7 @@ class MainViewController: UIViewController, UITextFieldDelegate {
         // loadingContainerView.isHidden = false
         // loadingIndicator.startAnimating()
 
-        let discoveryViewController = DiscoveryViewController(["test", "test", "test", "test"])
+        let discoveryViewController = DiscoveryViewController()
         navigationController?.pushViewController(discoveryViewController, animated: true)
     }
 

--- a/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
+++ b/SwiftAppTemplate/SwiftAppTemplate/MainViewController.swift
@@ -9,6 +9,8 @@
 import UIKit
 
 class MainViewController: UIViewController, UITextFieldDelegate {
+    private let statusImageView = UIImageView()
+    private let statusLabel = UILabel()
     private let paymentTextField = UITextField()
     private static let spacing: CGFloat = 50.0
     private static let stripeBlue = UIColor(red: 103.0/255.0, green:  114.0/255.0, blue: 229.0/255.0, alpha: 1.0)
@@ -29,6 +31,17 @@ class MainViewController: UIViewController, UITextFieldDelegate {
 
         paymentTextField.delegate = self
 
+        // You can change the set image and tintColor when connected to show some state
+        // bolt.fill or creditcard are some other handy symbols 🤷‍♂️
+        statusImageView.image = UIImage(systemName: "bolt.slash.fill")
+        statusImageView.contentMode = .scaleAspectFit
+        statusImageView.translatesAutoresizingMaskIntoConstraints = false
+        statusImageView.tintColor = .lightGray
+
+        // Change the status label text when connected too and could use it to show the reader messages
+        statusLabel.textAlignment = .center
+        statusLabel.text = "No reader connected"
+
         let discoverReadersButton = MainViewController.stripeyButton()
         discoverReadersButton.setTitle("Discover Readers", for: .normal)
         discoverReadersButton.addTarget(self, action: #selector(discoverReader), for: .touchUpInside)
@@ -43,6 +56,8 @@ class MainViewController: UIViewController, UITextFieldDelegate {
 
         let stackView = UIStackView(arrangedSubviews: [
             UIView(), // Spacer()
+            statusImageView,
+            statusLabel,
             discoverReadersButton,
             paymentTextField,
             collectPaymentButton,
@@ -59,6 +74,9 @@ class MainViewController: UIViewController, UITextFieldDelegate {
             stackView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -MainViewController.spacing),
             stackView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             stackView.leftAnchor.constraint(equalTo: self.view.leftAnchor, constant: MainViewController.spacing),
+            // Fixed size for the status image
+            statusImageView.widthAnchor.constraint(equalToConstant: 60),
+            statusImageView.heightAnchor.constraint(equalToConstant: 60),
         ])
     }
 


### PR DESCRIPTION
1. Reworked the mainVC a good bit
    1. simplified-ish layout with a stack view
    1. added an image and label for showing the connected reader status if wanted
    1. avoided the keyboard with some hacky constraint stuff to just shift the stack out of the way
1. added a spinner and mini cleanup to ListVC (now DiscoveryVC)
1. fixed the amount type issue
1. required iOS 13 for SF Icon usage
1. Added commented out chunks for the APIClient that should Just Work™ with the default example backend on heroku

| 👋 | ⌨️ |
| ------- | ------ | 
| <img width="559" alt="Screen Shot 2020-05-08 at 9 55 36 AM" src="https://user-images.githubusercontent.com/62762265/81430048-a06b1580-9113-11ea-9f3d-332152ca933a.png"> | <img width="559" alt="Screen Shot 2020-05-08 at 9 55 34 AM" src="https://user-images.githubusercontent.com/62762265/81430052-a4973300-9113-11ea-888f-0da9cce67e5c.png"> | 
